### PR TITLE
add more alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # positron
 List of electron apps so I can avoid them, and some alternatives to use instead
 
-## writing/notes
+# Avoid
+## Writing/notes
 * obsidian
 * logseq
 * joplin
@@ -16,11 +17,17 @@ List of electron apps so I can avoid them, and some alternatives to use instead
 * siyuan
 * affine
 * cubytext
-### Alternatives
+
+# Alternatives
+## Writing/notes
+* AlephNote
+* Notes
+* [xournalpp](https://github.com/xournalpp/xournalpp)
 * memos
 * mdsilo
 * idaebasic
 * appflowy
+
 ## music
 * nuclear
 * tidal

--- a/README.md
+++ b/README.md
@@ -1,55 +1,52 @@
-# positron
-List of electron apps so I can avoid them, and some alternatives to use instead
+<!--suppress HtmlDeprecatedAttribute -->
 
-# Avoid
-## Writing/notes
-* obsidian
-* logseq
-* joplin
-* notable
-* trillium
-* zettler
-* notable
-* notesnook
-* notion
-* nota
-* standard notes
-* siyuan
-* affine
-* cubytext
+<p align="center">
+  <img src="/dollar.gif" alt="BackEndBR" width="100px" />
+</p>
 
-# Alternatives
-## Writing/notes
-* AlephNote
-* Notes
-* [xournalpp](https://github.com/xournalpp/xournalpp)
-* memos
-* mdsilo
-* idaebasic
-* appflowy
+<p align="center">
+  <h1 align="center">Positron</h1>
+</p>
 
-## music
-* nuclear
-* tidal
-* splice
+Electron apps so I can avoid them, and some alternatives to use instead
 
-## social
-* discord
-* signal
-* skype
-* slack
+<div id='projects'></div>
 
-## development
-* figma
-* github desktop
-* hyper
-* visual studio code*
+| Name                      | type            | alternative     |
+|---------------------------|-----------------|-----------------|
+| obsidian |  Writing/notes | Alephnote |
+| logseq |  Writing/notes| Notes |
+| joplin |  Writing/notes| nvim, neovim, vi ... |
+| notable |  Writing/notes| notation |
+| trillium |  Writing/notes| sublimetext |
+| zettler |  Writing/notes|  [xournalpp](https://github.com/xournalpp/xournalpp) |
+| notable |  Writing/notes| memos |
+| notesnook |  Writing/notes|  mdsilo|
+| notion |  Writing/notes| idaebasic |
+| nota |  Writing/notes| appflowy |
+| standard notes  |  Writing/notes| |
+| siyuan |  Writing/notes| passnote |
+| affine |  Writing/notes| notepad++ |
+| cubytext | Writing/notes| notepad |
+| nuclear | music| spotify |
+| tidal | music| deezer |
+| splice | music| free spotify |
+| discord | social | nostr |
+| signal | social | blue-sky |
+| skype | social| friend-to-friend |
+| slack | social| mastodon |
+| figma | development| prototype |
+| github desktop | development| gogs |
+| hyper | development| github discussions |
+| visual studio | development| lite-xl |
+| youtube | video| freetube |
+| free  vpn | vpn | openvpn |
+| freepremium  vpn | vpn | mullvadvpn-app |
+| raven-reader | rss |  github rss |
 
-## video
-* freetube
+<div id='license'></div>
 
-## vpn
-* mullvadvpn-app
+## License
+BSD 3-Clause License
 
-## news feeds
-* raven-reader
+<div id='contributing'></div>


### PR DESCRIPTION
add [AlephNote](https://github.com/Mikescher/AlephNote), [Notes](https://github.com/nuttyartist/notes), [Xournalpp](https://github.com/xournalpp/xournalpp) as alternative Evernote, Obsian(eletron app).
Other interesting projects that I can contribute to if you want: [usememos/memos](https://github.com/usememos/memos), [Passpad](https://github.com/Mikescher/Passpad), [WizNotePlus](https://github.com/altairwei/WizNotePlus) and more.